### PR TITLE
(WIP) spec for pairing users

### DIFF
--- a/lib/pairing_helper.rb
+++ b/lib/pairing_helper.rb
@@ -1,0 +1,2 @@
+class PairingHelper
+end

--- a/spec/operations/pairing_spec.rb
+++ b/spec/operations/pairing_spec.rb
@@ -1,0 +1,40 @@
+require_relative "../../lib/pairing_helper.rb"
+
+describe PairingHelper do
+
+  let(:user1) { instance_double("User", skill: 2) }
+  let(:user2) { instance_double("User", skill: 1) }
+  let(:user3) { instance_double("User", skill: 3) }
+  let(:users) { [user1, user2] }
+
+  describe "#random_pair" do
+    subject { PairingHelper.new(users).random_pair }
+
+    context "with two users" do
+      it "pairs users up" do
+        expect(subject[:paired].size).to eq 1
+        expect(subject[:paired].first).to match_array([user1, user2])
+        expect(subject[:unpaired]).to be_empty
+      end
+    end
+
+    context "with more than two users" do
+      let(:users) { [user1, user2, user3] }
+      it "pairs users up randomly" do
+        expect(subject[:paired].size).to eq 1
+        expect(subject[:paired].first.first).to be_a User
+        expect(subject[:paired].first.last).to be_a User
+        expect(subject[:unpaired].size).to 1
+        expect(subject[:unpaired]).to be_a User
+      end
+    end
+
+    context "with one or less users" do
+      let(:users) { [user1] }
+      it "no pairs are made" do
+        expect(subject[:paired].size).to eq 0
+        expect(subject[:unpaired].size).to 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
Wrote some tests for the pairing operation. The PairingHelper class is not implemented yet, so all these tests currently fail (red, green, refactor).

Currently the tests expect:
- PairingHelper to initialize with an array of Users
- PairingHelper's `#random_pair` will pair those Users
  - the output will be a hash of two keys, `:paired`, and `:unpaired`, which will link to arrays of users

Users are currently mocked out, so that development of this can be independent of our actual User model.
