### PR TITLE
add signup feature test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.5'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'capybara'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (7.1.1)
     autoprefixer-rails (6.4.0.2)
       execjs
@@ -57,6 +58,13 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.2)
     byebug (9.0.5)
+    capybara (2.8.0)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -217,6 +225,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -225,6 +235,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   devise (>= 3.2.4)
   factory_girl_rails

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.feature "Signup", type: feature do
+  scenario "brand new user signs up for an account" do
+    visit "/sign_up"
+    fill_in "Email", with: 'abc@def.com'
+    fill_in "Password", with: 'abcdef1'
+    fill_in "Password confirmation", with: 'abcdef1'
+    click_on "Sign up"
+
+    expect(page.status_code).to eq 200
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'support/factories'
 require 'spec_helper'
 require 'rspec/rails'
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -55,4 +56,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Capybara::DSL
 end


### PR DESCRIPTION
This adds a basic test for signing up:
- go to sign_up page
- fill in the form
- click the sign up button

However, it exposes a current bug:

<img width="1228" alt="screen shot 2016-08-19 at 5 49 30 pm" src="https://cloud.githubusercontent.com/assets/4593934/17825285/648bb216-6635-11e6-901b-d3fcdac55d85.png">

This happens because we require more fields to be filled out than the signup form currently has:

<img width="395" alt="screen shot 2016-08-19 at 5 48 45 pm" src="https://cloud.githubusercontent.com/assets/4593934/17826305/50c80d6c-663d-11e6-9d72-97f702cc95b9.png">

<img width="813" alt="screen shot 2016-08-19 at 6 49 42 pm" src="https://cloud.githubusercontent.com/assets/4593934/17826335/bfdb5bdc-663d-11e6-8997-7f1513d9d2df.png">

So, the next thing to do would probably be to update the form with all the required fields, and then fix the test so that it fills all those fields out, and verifies that the sign up button does what it should do. This can be for a separate PR though.

Since this is more of a real bug, maybe it shouldn't be wipped and let the build fail, until it is fixed.
